### PR TITLE
Replacing `eval` with `fromJSON` in `clone` method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .settings
 .DS_Store
 *.pyc
-node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .settings
 .DS_Store
 *.pyc
+node_modules/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,6 @@
         "latex",
         "plaintext"
     ],
-    "workbench.colorTheme": "Default Light Modern",
+    "workbench.colorTheme": "Default Dark Modern",
     "python.terminal.executeInFileDir": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,6 @@
         "latex",
         "plaintext"
     ],
-    "workbench.colorTheme": "Default Dark Modern",
+    "workbench.colorTheme": "Default Light Modern",
     "python.terminal.executeInFileDir": true
 }

--- a/src/Constituent.js
+++ b/src/Constituent.js
@@ -4,7 +4,7 @@
  */
 
 import {getRules, getLexicon, getLanguage, quoteOOV } from "./Lexicon.js";
-import { exceptionOnWarning, savedWarnings, Pro } from "./jsRealB.js";
+import { exceptionOnWarning, savedWarnings, Pro, fromJSON } from "./jsRealB.js";
 export {Constituent, deprels}
 
 /**
@@ -51,6 +51,10 @@ class Constituent {
                            tauxNO:Constituent.tauxNO++};
             }
         }
+    }
+
+    clone(){
+        return fromJSON(this.toJSON(), this.lang);
     }
     
     /**

--- a/src/Constituent.js
+++ b/src/Constituent.js
@@ -53,6 +53,10 @@ class Constituent {
         }
     }
 
+    /**
+     * Creates a new copy of this instance by creating it from a JSON representation of this object
+     * @returns a deep copy of this instance
+     */
     clone(){
         return fromJSON(this.toJSON(), this.lang);
     }

--- a/src/Dependent.js
+++ b/src/Dependent.js
@@ -714,9 +714,9 @@ class Dependent extends Constituent {// Dependent (non-terminal)
      * to ensure that eval has access to all symbols now that packages are used
      * @returns a deep copy of this instance
      */
-    clone(){
+    /* clone(){
         return fromJSON(this.toJSON(), this.lang);
-    }
+    } */
 
     /**
      * Recreate a jsRealB expression

--- a/src/Dependent.js
+++ b/src/Dependent.js
@@ -715,7 +715,7 @@ class Dependent extends Constituent {// Dependent (non-terminal)
      * @returns a deep copy of this instance
      */
     clone(){
-        return fromJSON(this.toJSON());
+        return fromJSON(this.toJSON(), this.lang);
     }
 
     /**

--- a/src/Dependent.js
+++ b/src/Dependent.js
@@ -709,16 +709,6 @@ class Dependent extends Constituent {// Dependent (non-terminal)
     };
 
     /**
-     * Creates a new copy of this instance by creating it from a JSON representation of this object
-     * NB: this method is identical in subclasses of Constituent and cannot be defined in Constituent 
-     * to ensure that eval has access to all symbols now that packages are used
-     * @returns a deep copy of this instance
-     */
-    /* clone(){
-        return fromJSON(this.toJSON(), this.lang);
-    } */
-
-    /**
      * Recreate a jsRealB expression
      * if indent is non negative number create an indented pretty-print string (call it with 0 at the root)
      * if called with no parameter (equivalent to a negative number) then create a single line

--- a/src/Dependent.js
+++ b/src/Dependent.js
@@ -709,7 +709,7 @@ class Dependent extends Constituent {// Dependent (non-terminal)
     };
 
     /**
-     * Creates a new copy of this instance by evaluating a string representation of this object
+     * Creates a new copy of this instance by creating it from a JSON representation of this object
      * NB: this method is identical in subclasses of Constituent and cannot be defined in Constituent 
      * to ensure that eval has access to all symbols now that packages are used
      * @returns a deep copy of this instance

--- a/src/Dependent.js
+++ b/src/Dependent.js
@@ -5,7 +5,7 @@
     
 import { Constituent } from "./Constituent.js";
 import { Terminal } from "./Terminal.js";
-import { getElems, N,A,Pro,D,V,Adv,C,P,DT,NO,Q,dependent,det,subj, comp,root,mod,coord } from "./jsRealB.js" 
+import { getElems, N,A,Pro,D,V,Adv,C,P,DT,NO,Q,dependent,det,subj, comp,root,mod,coord, fromJSON } from "./jsRealB.js" 
 import { Phrase } from "./Phrase.js"
 import { getLanguage,getRules } from "./Lexicon.js";
 
@@ -715,7 +715,7 @@ class Dependent extends Constituent {// Dependent (non-terminal)
      * @returns a deep copy of this instance
      */
     clone(){
-        return eval(this.toSource());
+        return fromJSON(this.toJSON());
     }
 
     /**

--- a/src/Dependent.js
+++ b/src/Dependent.js
@@ -5,7 +5,7 @@
     
 import { Constituent } from "./Constituent.js";
 import { Terminal } from "./Terminal.js";
-import { getElems, N,A,Pro,D,V,Adv,C,P,DT,NO,Q,dependent,det,subj, comp,root,mod,coord, fromJSON } from "./jsRealB.js" 
+import { getElems,Pro,P,NO,Q,dependent,det,comp } from "./jsRealB.js" 
 import { Phrase } from "./Phrase.js"
 import { getLanguage,getRules } from "./Lexicon.js";
 

--- a/src/Phrase.js
+++ b/src/Phrase.js
@@ -819,9 +819,9 @@ class Phrase extends Constituent{
      * to ensure that eval has access to all symbols now that packages are used
      * @returns a deep copy of this instance
      */
-    clone(){
+    /*clone(){
         return fromJSON(this.toJSON(), this.lang);
-    }
+    }*/
 
     /**
      * Recreate a jsRealB expression

--- a/src/Phrase.js
+++ b/src/Phrase.js
@@ -8,7 +8,7 @@ import { Terminal } from "./Terminal.js";
 // must import all functions because of possible eval call by clone
 import { getElems, N,A,Pro,D,V,Adv,C,P,DT,NO,Q,
          S,NP,AP,VP,AdvP,PP,CP,SP,
-         root, subj, det, mod, comp, coord } from "./jsRealB.js"
+         root, subj, det, mod, comp, coord, fromJSON } from "./jsRealB.js"
 import {getLanguage,getRules,reorderVPcomplements} from "./Lexicon.js";
 
 export {Phrase};
@@ -820,7 +820,7 @@ class Phrase extends Constituent{
      * @returns a deep copy of this instance
      */
     clone(){
-        return eval(this.toSource());
+        return fromJSON(this.toJSON());
     }
 
     /**

--- a/src/Phrase.js
+++ b/src/Phrase.js
@@ -820,7 +820,7 @@ class Phrase extends Constituent{
      * @returns a deep copy of this instance
      */
     clone(){
-        return fromJSON(this.toJSON());
+        return fromJSON(this.toJSON(), this.lang);
     }
 
     /**

--- a/src/Phrase.js
+++ b/src/Phrase.js
@@ -814,7 +814,7 @@ class Phrase extends Constituent{
     };
     
     /**
-     * Creates a new copy of this instance by evaluating a string representation of this object
+     * Creates a new copy of this instance by creating it from a JSON representation of this object
      * NB: this method is identical in subclasses of Constituent and cannot be defined in Constituent 
      * to ensure that eval has access to all symbols now that packages are used
      * @returns a deep copy of this instance

--- a/src/Phrase.js
+++ b/src/Phrase.js
@@ -5,10 +5,7 @@
 
 import { Constituent } from "./Constituent.js";
 import { Terminal } from "./Terminal.js";
-// must import all functions because of possible eval call by clone
-import { getElems, N,A,Pro,D,V,Adv,C,P,DT,NO,Q,
-         S,NP,AP,VP,AdvP,PP,CP,SP,
-         root, subj, det, mod, comp, coord, fromJSON } from "./jsRealB.js"
+import { getElems,Pro,P,NO,Q,PP } from "./jsRealB.js"
 import {getLanguage,getRules,reorderVPcomplements} from "./Lexicon.js";
 
 export {Phrase};

--- a/src/Phrase.js
+++ b/src/Phrase.js
@@ -812,16 +812,6 @@ class Phrase extends Constituent{
         }
         return this.doFormat(res);
     };
-    
-    /**
-     * Creates a new copy of this instance by creating it from a JSON representation of this object
-     * NB: this method is identical in subclasses of Constituent and cannot be defined in Constituent 
-     * to ensure that eval has access to all symbols now that packages are used
-     * @returns a deep copy of this instance
-     */
-    /*clone(){
-        return fromJSON(this.toJSON(), this.lang);
-    }*/
 
     /**
      * Recreate a jsRealB expression

--- a/src/Terminal.js
+++ b/src/Terminal.js
@@ -6,10 +6,7 @@
 import { Constituent,deprels } from "./Constituent.js";
 import { getLanguage,getLexicon,getRules, quoteOOV } from "./Lexicon.js";
 import { nbDecimal,numberFormatter, enToutesLettres, ordinal, roman} from "./Number.js";
-// must import all functions because of possible eval call by clone
-import { getElems, N,A,Pro,D,V,Adv,C,P,DT,NO,Q,
-    S,NP,AP,VP,AdvP,PP,CP,SP,
-    root, subj, det, mod, comp, coord, fromJSON } from "./jsRealB.js"
+import { NO } from "./jsRealB.js"
 
 export {Terminal}
 

--- a/src/Terminal.js
+++ b/src/Terminal.js
@@ -9,7 +9,7 @@ import { nbDecimal,numberFormatter, enToutesLettres, ordinal, roman} from "./Num
 // must import all functions because of possible eval call by clone
 import { getElems, N,A,Pro,D,V,Adv,C,P,DT,NO,Q,
     S,NP,AP,VP,AdvP,PP,CP,SP,
-    root, subj, det, mod, comp, coord } from "./jsRealB.js"
+    root, subj, det, mod, comp, coord, fromJSON } from "./jsRealB.js"
 
 export {Terminal}
 
@@ -593,7 +593,7 @@ class Terminal extends Constituent{
      * @returns a deep copy of this instance
      */
     clone(){
-        return eval(this.toSource());
+        return fromJSON(this.toJSON());
     }
 
     /**

--- a/src/Terminal.js
+++ b/src/Terminal.js
@@ -585,17 +585,6 @@ class Terminal extends Constituent{
         return roman(number)
     }
 
-
-    /**
-     * Creates a new copy of this instance by creating it from a JSON representation of this object
-     * NB: this method is identical in subclasses of Constituent and cannot be defined in Constituent 
-     * to ensure that eval has access to all symbols now that packages are used
-     * @returns a deep copy of this instance
-     */
-    /*clone(){
-        return fromJSON(this.toJSON(), this.lang);
-    }*/
-
     /**
      * Produce the string form of a Terminal
      * @returns string corresponding to the creation of this Terminal

--- a/src/Terminal.js
+++ b/src/Terminal.js
@@ -592,9 +592,9 @@ class Terminal extends Constituent{
      * to ensure that eval has access to all symbols now that packages are used
      * @returns a deep copy of this instance
      */
-    clone(){
+    /*clone(){
         return fromJSON(this.toJSON(), this.lang);
-    }
+    }*/
 
     /**
      * Produce the string form of a Terminal

--- a/src/Terminal.js
+++ b/src/Terminal.js
@@ -587,7 +587,7 @@ class Terminal extends Constituent{
 
 
     /**
-     * Creates a new copy of this instance by evaluating a string representation of this object
+     * Creates a new copy of this instance by creating it from a JSON representation of this object
      * NB: this method is identical in subclasses of Constituent and cannot be defined in Constituent 
      * to ensure that eval has access to all symbols now that packages are used
      * @returns a deep copy of this instance

--- a/src/Terminal.js
+++ b/src/Terminal.js
@@ -593,7 +593,7 @@ class Terminal extends Constituent{
      * @returns a deep copy of this instance
      */
     clone(){
-        return fromJSON(this.toJSON());
+        return fromJSON(this.toJSON(), this.lang);
     }
 
     /**

--- a/tests-dev.js
+++ b/tests-dev.js
@@ -875,7 +875,7 @@ function testWarnings(){
 
 Constituent.debug = true;   // useful for tracing, but then .realize() must be called.
 //  To check a single "new" example, comment the following
-// testPreviousExamples()
+ testPreviousExamples()
 // testWarnings()
 //  Add an example within a call to test(...) which displays the indented source of the expression and its realization 
 //  Do not forget to "load" the appropriate language

--- a/tests-dev.js
+++ b/tests-dev.js
@@ -875,7 +875,7 @@ function testWarnings(){
 
 Constituent.debug = true;   // useful for tracing, but then .realize() must be called.
 //  To check a single "new" example, comment the following
- testPreviousExamples()
+// testPreviousExamples()
 // testWarnings()
 //  Add an example within a call to test(...) which displays the indented source of the expression and its realization 
 //  Do not forget to "load" the appropriate language


### PR DESCRIPTION
Use of `eval` in JavaScript is generally discouraged (see [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#never_use_eval!)) and many projects (including our own hope to avoid it in our code bases. This PR replaces the use of `eval` in the `clone` methods of `Terminal`, `Phrase`, and `Dependent` with the use of `fromJSON` and `toJSON`. This change also means that a single definition of `clone` on `Constituent` is possible.